### PR TITLE
upgrade to scala 2.11 and scalatest 3.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ version := "0.2"
 
 organization := "com.ankurdave"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.8"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.0" % "test"
 
 javaOptions += "-Xmx10G"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ version := "0.2"
 
 organization := "com.ankurdave"
 
+crossScalaVersions := Seq("2.10.6", "2.11.8")
 scalaVersion := "2.11.8"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.0" % "test"


### PR DESCRIPTION
the initial motivation for this change is that i want to port https://github.com/amplab/spark-indexedrdd to work with spark 2 and scala 2.11
